### PR TITLE
Tuple bytecode changes

### DIFF
--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -54,8 +54,9 @@ pub enum Instr {
     /// Jumps program execution by n instructions if a is true, else it jumps by m instructions
     /// Note that a must be a boolean, otherwise the program is invalid.
     CondJump(Addr, i8, i8),
-    /// Constructs a tuple from a contiguous range of slots, a = (b..c)
-    MkTup(Addr, Addr, Addr),
+    /// Constructs a tuple, a = (b; c)
+    /// Takes a contiguous range of c slots starting at b, a = (_; 0) builds the empty tuple.
+    MkTup(Addr, Addr, u8),
     /// Indexes a tuple a = b[c]
     IdxTup(Addr, Addr, Addr),
     /// Calls a function, a = b(c).
@@ -92,7 +93,7 @@ impl fmt::Display for Instr {
             Geq(a, b, c) => write!(fmt, "x{} := x{} >= x{}", a, b, c),
             Jump(off) => write!(fmt, "jump {}", off),
             CondJump(a, b, c) => write!(fmt, "cond x{} {} {}", a, b, c),
-            MkTup(a, b, c) => write!(fmt, "x{} := (x{}..x{})", a, b, c),
+            MkTup(a, b, c) => write!(fmt, "x{} := (x{}; {})", a, b, c),
             IdxTup(a, b, c) => write!(fmt, "x{} := x{}[x{}]", a, b, c),
             Call(a, b, c) => write!(fmt, "x{} := x{}(x{})", a, b, c),
             Return(None) => write!(fmt, "return"),
@@ -207,7 +208,7 @@ impl Program {
                 &Leq(a, b, c) => locals[a as usize] = B(&locals[b as usize] <= &locals[c as usize]),
                 &Geq(a, b, c) => locals[a as usize] = B(&locals[b as usize] >= &locals[c as usize]),
                 &MkTup(a, b, c) => {
-                    locals[a as usize] = T(locals[b as usize..c as usize + 1].into())
+                    locals[a as usize] = T(locals[b as usize..(b + c) as usize].into())
                 }
                 &IdxTup(a, t, i) => {
                     locals[a as usize] = match (&locals[t as usize], &locals[i as usize]) {

--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -57,6 +57,9 @@ pub enum Instr {
     /// Constructs a tuple, a = (b; c)
     /// Takes a contiguous range of c slots starting at b, a = (_; 0) builds the empty tuple.
     MkTup(Addr, Addr, u8),
+    /// Destructs a tuple (a; b) = c
+    /// Unpacks c into a contiguous range of b slots starting at a.
+    UnTup(Addr, u8, Addr),
     /// Indexes a tuple a = b[c]
     IdxTup(Addr, Addr, Addr),
     /// Calls a function, a = b(c).
@@ -94,6 +97,7 @@ impl fmt::Display for Instr {
             Jump(off) => write!(fmt, "jump {}", off),
             CondJump(a, b, c) => write!(fmt, "cond x{} {} {}", a, b, c),
             MkTup(a, b, c) => write!(fmt, "x{} := (x{}; {})", a, b, c),
+            UnTup(a, b, c) => write!(fmt, "(x{}; {}) := x{}", a, b, c),
             IdxTup(a, b, c) => write!(fmt, "x{} := x{}[x{}]", a, b, c),
             Call(a, b, c) => write!(fmt, "x{} := x{}(x{})", a, b, c),
             Return(None) => write!(fmt, "return"),
@@ -209,6 +213,13 @@ impl Program {
                 &Geq(a, b, c) => locals[a as usize] = B(&locals[b as usize] >= &locals[c as usize]),
                 &MkTup(a, b, c) => {
                     locals[a as usize] = T(locals[b as usize..(b + c) as usize].into())
+                }
+                &UnTup(a, b, c) => {
+                    let c = match locals[c as usize] {
+                        T(ref c) if c.len() == b as usize => c.clone(),
+                        _ => return Err(EvalError {}),
+                    };
+                    locals[a as usize..(a + b) as usize].clone_from_slice(&c[..])
                 }
                 &IdxTup(a, t, i) => {
                     locals[a as usize] = match (&locals[t as usize], &locals[i as usize]) {

--- a/src/bytecode/parse.rs
+++ b/src/bytecode/parse.rs
@@ -130,9 +130,12 @@ pub fn parse(text: &str) -> Result<Program, ParseError> {
                         buf.end()?;
                         defn.code.push(Const(dest, k));
                     } else if buf.starts_with("(") {
-                        // x0 := (x1..x2)
+                        // x0 := (x1; #)
                         let (buf, b) = buf.trim_left().token("(")?.addr("x")?;
-                        let (buf, c) = buf.trim_left().token("..")?.addr("x")?;
+                        let (buf, c) = buf.trim_left()
+                            .token(";")?
+                            .trim_left()
+                            .parse_til(|c| !(c.is_digit(10)))?;
                         buf.trim_left().token(")")?.end()?;
                         defn.code.push(MkTup(dest, b, c));
                     } else if buf.starts_with("read") {

--- a/src/bytecode/parse.rs
+++ b/src/bytecode/parse.rs
@@ -106,7 +106,7 @@ pub fn parse(text: &str) -> Result<Program, ParseError> {
                     defn.code.push(Write(addr));
                 } else if buf.starts_with("jump") {
                     // jump 10
-                    let (buf, br): (_, i16) = buf.token("jump")?
+                    let (buf, br) = buf.token("jump")?
                         .space()?
                         .parse_til(|c| !(c.is_digit(10) || c == '-'))?;
                     buf.end()?;
@@ -114,12 +114,24 @@ pub fn parse(text: &str) -> Result<Program, ParseError> {
                 } else if buf.starts_with("cond") {
                     // cond x0 10 20
                     let (buf, addr) = buf.token("cond")?.space()?.addr("x")?;
-                    let (buf, br1): (_, i8) =
-                        buf.space()?.parse_til(|c| !(c.is_digit(10) || c == '-'))?;
-                    let (buf, br2): (_, i8) =
-                        buf.space()?.parse_til(|c| !(c.is_digit(10) || c == '-'))?;
+                    let (buf, br1) = buf.space()?.parse_til(|c| !(c.is_digit(10) || c == '-'))?;
+                    let (buf, br2) = buf.space()?.parse_til(|c| !(c.is_digit(10) || c == '-'))?;
                     buf.end()?;
                     defn.code.push(CondJump(addr, br1, br2));
+                } else if buf.starts_with("(") {
+                    let (buf, dest) = buf.token("(")?.trim_left().addr("x")?;
+                    let (buf, len) = buf.trim_left()
+                        .token(";")?
+                        .trim_left()
+                        .parse_til(|c| !c.is_digit(10))?;
+                    let (buf, src) = buf.trim_left()
+                        .token(")")?
+                        .trim_left()
+                        .token(":=")?
+                        .trim_left()
+                        .addr("x")?;
+                    buf.end()?;
+                    defn.code.push(UnTup(dest, len, src));
                 } else {
                     // x0 := ...
                     let (buf, dest) = buf.addr("x")?;
@@ -135,7 +147,7 @@ pub fn parse(text: &str) -> Result<Program, ParseError> {
                         let (buf, c) = buf.trim_left()
                             .token(";")?
                             .trim_left()
-                            .parse_til(|c| !(c.is_digit(10)))?;
+                            .parse_til(|c| !c.is_digit(10))?;
                         buf.trim_left().token(")")?.end()?;
                         defn.code.push(MkTup(dest, b, c));
                     } else if buf.starts_with("read") {

--- a/src/bytecode/tests.rs
+++ b/src/bytecode/tests.rs
@@ -297,6 +297,52 @@ return x0
     result: Ok(I(15 / (((1 + 2) * (1 + 2)) % 7)));
 }
 
+test_program! {
+    name: untup;
+    text: r#"
+defn f0 2 : f1
+  x0 := read
+  x1 := read
+  x0 := (x0; 2)
+  x1 := k0
+  x0 := x1(x0)
+  (x0; 2) := x0
+  write x0
+  write x1
+
+defn f1 3 :
+  (x0; 2) := x0
+  x2 := x0
+  x0 := (x1; 2)
+  return x0
+"#;
+    defn {
+        code: [
+            Read(0),
+            Read(1),
+            MkTup(0, 0, 2),
+            Const(1, 0),
+            Call(0, 1, 0),
+            UnTup(0, 2, 0),
+            Write(0),
+            Write(1),
+        ],
+        consts: [C(1)],
+        local_count: 2,
+    }
+    defn {
+        code: [
+            UnTup(0, 2, 0),
+            Copy(2, 0),
+            MkTup(0, 1, 2),
+            Return(Some(0)),
+        ],
+        consts: [],
+        local_count: 3,
+    }
+    result: Ok(T(vec![]));
+}
+
 #[test]
 fn io() {
     use self::Val::*;

--- a/src/bytecode/tests.rs
+++ b/src/bytecode/tests.rs
@@ -225,7 +225,7 @@ test_program! {
 defn f0 2 : 42 69 f1
 x0 := k0
 x1 := k1
-x0 := (x0..x1)
+x0 := (x0; 2)
 x1 := k2
 x0 := x1(x0)
 return x0
@@ -242,7 +242,7 @@ return x0
         code: [
             Const(0, 0),
             Const(1, 1),
-            MkTup(0, 0, 1),
+            MkTup(0, 0, 2),
             Const(1, 2),
             Call(0, 1, 0),
             Return(Some(0)),
@@ -355,7 +355,7 @@ fn test_format() {
                         code: vec![
                             Const(0, 0),
                             Const(1, 1),
-                            MkTup(0, 0, 1),
+                            MkTup(0, 0, 2),
                             Const(1, 2),
                             Call(0, 1, 0),
                             Return(Some(0)),
@@ -382,7 +382,7 @@ fn test_format() {
         r#"defn f0 2 : 42 69 f1
     x0 := k0
     x1 := k1
-    x0 := (x0..x1)
+    x0 := (x0; 2)
     x1 := k2
     x0 := x1(x0)
     return x0


### PR DESCRIPTION
This changes the behavior of the `MkTup` instruction to use a different range encoding, to simplify some math and enable empty tuples. Fixes #15 

This also adds the `UnTup` instruction, to simplify argument unpacking and multiple returns. Fixes #16 

Finally, this adds testing for I/O in the `test_program!` macro.
  